### PR TITLE
Use Marshal instead of YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You have to create the table used by the Settings model by using this migration:
       def self.up
         create_table :settings, :force => true do |t|
           t.string  :var,         :null => false
-          t.text    :value
+          t.binary  :value
           t.integer :target_id
           t.string  :target_type, :limit => 30
           t.timestamps

--- a/lib/rails-settings/settings.rb
+++ b/lib/rails-settings/settings.rb
@@ -87,14 +87,14 @@ class Settings < ActiveRecord::Base
     target_scoped.find_by_var(var_name.to_s)
   end
 
-  #get the value field, YAML decoded
+  #get the value field, Marshal decoded
   def value
-    YAML::load(self[:value])
+    Marshal.load(self[:value])
   end
 
-  #set the value field, YAML encoded
+  #set the value field, Marshal encoded
   def value=(new_value)
-    self[:value] = new_value.to_yaml
+    self[:value] = Marshal.dump(new_value)
   end
 
   def self.target_scoped


### PR DESCRIPTION
Really digging into the past here but there was a [lighthouse ticket in 2008](https://rails.lighthouseapp.com/projects/8994/tickets/1191-marshal-serialized-attributes) that has Marshal being the faster parser. By a lot.

http://www.pauldix.net/2008/08/serializing-dat.html
http://pivotallabs.com/users/colin/blog/articles/980-marshal-dump-vs-yaml-dump
