### PR TITLE
add attr_accessible for updating. override value_before_type_cast so co...

### DIFF
--- a/lib/rails-settings/settings.rb
+++ b/lib/rails-settings/settings.rb
@@ -1,6 +1,7 @@
 class Settings < ActiveRecord::Base
+  attr_accessible :var, :value, :target_type
   class SettingNotFound < RuntimeError; end
-  
+
   cattr_accessor :defaults
   self.defaults = {}.with_indifferent_access
 
@@ -8,28 +9,28 @@ class Settings < ActiveRecord::Base
   if defined?(SettingsDefaults::DEFAULTS)
     self.defaults = SettingsDefaults::DEFAULTS.with_indifferent_access
   end
-  
+
   #get or set a variable with the variable as the called method
   def self.method_missing(method, *args)
     if self.respond_to?(method)
       super
     else
       method_name = method.to_s
-    
+
       #set a value for a variable
       if method_name =~ /=$/
         var_name = method_name.gsub('=', '')
         value = args.first
         self[var_name] = value
-    
+
       #retrieve a value
       else
         self[method_name]
-      
+
       end
     end
   end
-  
+
   #destroy the specified settings record
   def self.destroy(var_name)
     var_name = var_name.to_s
@@ -45,7 +46,7 @@ class Settings < ActiveRecord::Base
   def self.all(starting_with=nil)
     options = starting_with ? { :conditions => "var LIKE '#{starting_with}%'"} : {}
     vars = target_scoped.find(:all, {:select => 'var, value'}.merge(options))
-    
+
     result = {}
     vars.each do |record|
       result[record.var] = record.value
@@ -54,7 +55,7 @@ class Settings < ActiveRecord::Base
     selected_defaults = Hash[selected_defaults] if selected_defaults.is_a?(Array)
     selected_defaults.merge(result).with_indifferent_access
   end
-  
+
   #get a setting value by [] notation
   def self.[](var_name)
     if var = target(var_name)
@@ -67,7 +68,7 @@ class Settings < ActiveRecord::Base
       end
     end
   end
-  
+
   #set a setting value by [] notation
   def self.[]=(var_name, value)
     record = target_scoped.find_or_initialize_by_var(var_name.to_s)
@@ -75,42 +76,46 @@ class Settings < ActiveRecord::Base
     record.save!
     value
   end
-  
+
   def self.merge!(var_name, hash_value)
     raise ArgumentError unless hash_value.is_a?(Hash)
-    
+
     old_value = self[var_name] || {}
     raise TypeError, "Existing value is not a hash, can't merge!" unless old_value.is_a?(Hash)
-    
+
     new_value = old_value.merge(hash_value)
     self[var_name] = new_value if new_value != old_value
-    
+
     new_value
   end
 
   def self.target(var_name)
     target_scoped.find_by_var(var_name.to_s)
   end
-  
+
   #get the value field, YAML decoded
   def value
     YAML::load(self[:value])
   end
-  
+
   #set the value field, YAML encoded
   def value=(new_value)
     self[:value] = new_value.to_yaml
   end
-  
+
+  def value_before_type_cast
+    value
+  end
+
   def self.target_scoped
     Settings.scoped_by_target_type_and_target_id(target_type, target_id)
   end
-  
+
   #Deprecated!
   def self.reload # :nodoc:
     self
   end
-  
+
   def self.target_id
     nil
   end

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 
 class SettingsTest < Test::Unit::TestCase
   setup_db
-  
+
   def setup
     Settings.create!(:var => 'test',  :value => 'foo')
     Settings.create!(:var => 'test2', :value => 'bar')
-    
+
     # Reset defaults
     Settings.defaults = {}.with_indifferent_access
   end
@@ -15,18 +15,18 @@ class SettingsTest < Test::Unit::TestCase
     User.delete_all
     Settings.delete_all
   end
-  
+
   def test_defaults
     Settings.defaults[:foo] = 'default foo'
-    
+
     assert_nil Settings.target(:foo)
     assert_equal 'default foo', Settings.foo
-    
+
     Settings.foo = 'bar'
     assert_equal 'bar', Settings.foo
     assert_not_nil Settings.target(:foo)
   end
-  
+
   def tests_defaults_true
     Settings.defaults[:foo] = true
     assert_equal true, Settings.foo
@@ -36,7 +36,7 @@ class SettingsTest < Test::Unit::TestCase
     Settings.defaults[:foo] = false
     assert_equal false, Settings.foo
   end
-  
+
   def test_get
     assert_setting 'foo', :test
     assert_setting 'bar', :test2
@@ -45,85 +45,85 @@ class SettingsTest < Test::Unit::TestCase
   def test_update
     assert_assign_setting '321', :test
   end
-  
+
   def test_create
     assert_assign_setting '123', :onetwothree
   end
-  
+
   def test_complex_serialization
     complex = [1, '2', {:three => true}]
     Settings.complex = complex
     assert_equal complex, Settings.complex
   end
-  
+
   def test_serialization_of_float
     Settings.float = 0.01
     Settings.reload
     assert_equal 0.01, Settings.float
     assert_equal 0.02, Settings.float * 2
   end
-  
+
   def test_target_scope
     user1 = User.create! :name => 'First user'
     user2 = User.create! :name => 'Second user'
-    
+
     assert_assign_setting 1, :one, user1
     assert_assign_setting 2, :two, user2
-    
+
     assert_setting 1, :one, user1
     assert_setting 2, :two, user2
-    
+
     assert_setting nil, :one
     assert_setting nil, :two
-    
+
     assert_setting nil, :two, user1
     assert_setting nil, :one, user2
-    
+
     assert_equal({ "one" => 1}, user1.settings.all('one'))
     assert_equal({ "two" => 2}, user2.settings.all('two'))
     assert_equal({ "one" => 1}, user1.settings.all('o'))
     assert_equal({}, user1.settings.all('non_existing_var'))
   end
-  
+
   def test_named_scope
     user_without_settings = User.create! :name => 'User without settings'
     user_with_settings = User.create! :name => 'User with settings'
     user_with_settings.settings.one = '1'
     user_with_settings.settings.two = '2'
-    
+
     assert_equal [user_with_settings], User.with_settings
     assert_equal [user_with_settings], User.with_settings_for('one')
     assert_equal [user_with_settings], User.with_settings_for('two')
     assert_equal [], User.with_settings_for('foo')
-    
+
     assert_equal [user_without_settings], User.without_settings
     assert_equal [user_without_settings], User.without_settings_for('one')
     assert_equal [user_without_settings], User.without_settings_for('two')
     assert_equal [user_without_settings, user_with_settings], User.without_settings_for('foo')
   end
-  
+
   def test_delete_settings_after_destroying_target
     user1 = User.create! :name => 'Mr. Foo'
     user2 = User.create! :name => 'Mr. Bar'
     user1.settings.example = 42
     user2.settings.example = 43
-    
+
     before_count = Settings.count
     user1.destroy
     assert_equal before_count - 1, Settings.count
-    
+
     before_count = Settings.count
     user2.destroy
     assert_equal before_count - 1, Settings.count
   end
-  
+
   def test_all
     assert_equal({ "test2" => "bar", "test" => "foo" }, Settings.all)
     assert_equal({ "test2" => "bar" }, Settings.all('test2'))
     assert_equal({ "test2" => "bar", "test" => "foo" }, Settings.all('test'))
     assert_equal({}, Settings.all('non_existing_var'))
   end
-  
+
   def test_merge
     assert_raise(TypeError) do
       Settings.merge! :test, { :a => 1 }
@@ -132,39 +132,39 @@ class SettingsTest < Test::Unit::TestCase
     Settings[:hash] = { :one => 1 }
     Settings.merge! :hash, { :two => 2 }
     assert_equal({ :one => 1, :two => 2 }, Settings[:hash])
-    
+
     assert_raise(ArgumentError) do
       Settings.merge! :hash, 123
     end
-    
+
     Settings.merge! :empty_hash, { :two => 2 }
     assert_equal({ :two => 2 }, Settings[:empty_hash])
   end
-  
+
   def test_association_merge
     user = User.create! :name => 'Mr. Foo'
     user.settings.merge! :foo, { :one => 1, :two => 2}
 
     assert_equal({:one => 1, :two => 2}, user.settings.foo)
   end
-  
+
   def test_destroy
     Settings.destroy :test
     assert_equal nil, Settings.test
-    
+
     assert_raise(Settings::SettingNotFound) do
       Settings.destroy :unknown
     end
   end
-  
+
   def test_false
     Settings.test3 = false
     assert_setting(false, 'test3')
-    
+
     Settings.destroy :test3
     assert_setting(nil, 'test3')
   end
-  
+
   def test_class_level_settings
     assert_equal User.settings.name, "ScopedSettings"
   end
@@ -172,9 +172,9 @@ class SettingsTest < Test::Unit::TestCase
   def test_object_inherits_class_settings_before_default
     Settings.defaults[:foo] = 'global default'
     User.settings.foo = 'model default'
-    
+
     user = User.create! :name => 'Dwight'
-    
+
     assert_equal user.settings.foo, 'model default'
     assert_equal 'global default', Settings.foo
   end
@@ -189,7 +189,7 @@ class SettingsTest < Test::Unit::TestCase
     user.settings[:one] = '1'
     user.settings[:two] = '2'
     user.settings = { :two => '2a', :three => '3' }
-    
+
     assert_equal '1',  user.settings[:one]   # ensure existing settings remain intact
     assert_equal '2a', user.settings[:two]   # ensure settings are properly overwritten
     assert_equal '3',  user.settings[:three] # ensure new setting are created
@@ -200,19 +200,27 @@ class SettingsTest < Test::Unit::TestCase
     user = User.create! :name => 'Mr. Foo'
     assert_equal({ 'foo' => 'bar' }, user.settings.all)
   end
-  
+
   def test_issue_18
     Settings.one = 'value1'
     User.settings.two = 'value2'
-    
+
     assert_equal({'two' => 'value2'}, User.settings.all)
   end
-  
 
+  def test_create_instance
+    setting = Settings.create var: 'one', value: 'value4'
+    assert_equal('value4', Settings.one)
+  end
+
+  def test_before_type_cast_returns_correct_value
+    Settings.one = 'value1'
+    assert_equal('value1', Settings.find_by_var('one').value_before_type_cast)
+  end
   private
     def assert_setting(value, key, scope_target=nil)
       key = key.to_sym
-      
+
       if scope_target
         assert_equal value, scope_target.instance_eval("settings.#{key}")
         assert_equal value, scope_target.settings[key.to_sym]
@@ -223,22 +231,22 @@ class SettingsTest < Test::Unit::TestCase
         assert_equal value, Settings[key.to_s]
       end
     end
-    
+
     def assert_assign_setting(value, key, scope_target=nil)
       key = key.to_sym
-      
+
       if scope_target
         assert_equal value, (scope_target.settings[key] = value)
         assert_setting value, key, scope_target
         scope_target.settings[key] = nil
-      
+
         assert_equal value, (scope_target.settings[key.to_s] = value)
         assert_setting value, key, scope_target
       else
         assert_equal value, (Settings[key] = value)
         assert_setting value, key
         Settings[key] = nil
-      
+
         assert_equal value, (Settings[key.to_s] = value)
         assert_setting value, key
       end


### PR DESCRIPTION
I had two issues when trying to user Settings in a rails form. Update failed mass assignment validation since attr_accessible was missing. Added it.

text_field displays the YAML format stored in the database. Override active-record method to return the YAML parsed value. 
