### PR TITLE
Quick and dirty fix for design flaw in target scope implementation.

### DIFF
--- a/lib/rails-settings/scoped_settings.rb
+++ b/lib/rails-settings/scoped_settings.rb
@@ -1,7 +1,13 @@
 class ScopedSettings < Settings
+
+  @klasses = {}
+
   def self.for_target(target)
-    @target = target
-    self
+    @klasses[target] ||= self.dup.instance_eval do
+      def name; "ScopedSettings"; end # Required by ActiveModel::Naming
+      @target = target
+      self
+    end
   end
   
   def self.target_id

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -78,13 +78,25 @@ class SettingsTest < Test::Unit::TestCase
     
     assert_setting nil, :two, user1
     assert_setting nil, :one, user2
-    
+
     assert_equal({ "one" => 1}, user1.settings.all('one'))
     assert_equal({ "two" => 2}, user2.settings.all('two'))
     assert_equal({ "one" => 1}, user1.settings.all('o'))
     assert_equal({}, user1.settings.all('non_existing_var'))
   end
-  
+
+  def test_target_scope_is_instance_safe
+    user1 = User.create! :name => 'First user'
+    user2 = User.create! :name => 'Second user'
+
+    assert_assign_setting 'Foo one', :foo, user1
+    assert_assign_setting 'Foo two', :foo, user2
+
+    settings_1 = user1.settings
+    settings_2 = user2.settings
+    assert_equal 'Foo one', settings_1.foo
+  end
+
   def test_named_scope
     user_without_settings = User.create! :name => 'User without settings'
     user_with_settings = User.create! :name => 'User with settings'


### PR DESCRIPTION
Hi Georg,

Here is a fix for the issue I mentioned by email, with an accompanying test.

I think a proper fix would require a serious redesign: to stop using (and reusing) the ScopedSettings class itself as a kind of container for the settings of a model, but use instances of a class instead.

Anyway, until then, the proposed fix should plug the leaks.

Cheers, and thanks again for your great work!
## 

Yves-Eric
