### PR TITLE
Adding the ability to define class level default settings in the same call to...

### DIFF
--- a/lib/rails-settings/active_record.rb
+++ b/lib/rails-settings/active_record.rb
@@ -1,5 +1,5 @@
 ActiveRecord::Base.class_eval do
-  def self.has_settings
+  def self.has_settings(default_settings=nil)
     class_eval do
       def settings
         ScopedSettings.for_target(self)
@@ -11,6 +11,10 @@ ActiveRecord::Base.class_eval do
 
       def settings=(hash)
         hash.each { |k,v| settings[k] = v }
+      end
+
+      def self.settings=(hash)
+        hash.each { |k,v| self.settings[k] = v }
       end
 
       after_destroy { |user| user.settings.target_scoped.delete_all }
@@ -34,5 +38,6 @@ ActiveRecord::Base.class_eval do
                                                                                       settings.var = '#{var}'",
                                                                  :conditions => 'settings.id IS NULL' } }
     end
+    self.settings = default_settings if default_settings
   end
 end

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -196,6 +196,14 @@ class SettingsTest < Test::Unit::TestCase
     assert_equal User.settings.foo, 'bar'
   end
 
+  def test_class_declaration_sets_defaults_with_hash
+    User.has_settings :baz => "baz", :qux => "qux"
+    user = User.create! :name => 'Mr. Foo'
+    user.settings.qux = 'quxx' 
+    assert_equal 'baz',  user.settings[:baz]  # ensure class level defaults exist
+    assert_equal 'quxx', user.settings[:qux]   # ensure settings are properly overwritten
+  end
+
   def test_sets_settings_with_hash
     user = User.create! :name => 'Mr. Foo'
     user.settings[:one] = '1'


### PR DESCRIPTION
... 'has_settings'.

So you can do this

```
class User < ActiveRecord::Base
  has_settings :foo => "foo",
               :bar => "bar"
end
```

instead of this:

```
class User < ActiveRecord::Base
  has_settings 
  self.settings[:foo] = "foo"
  self.settings[:bar] = "bar"
end
```
