### PR TITLE
 Fixed bug for boolean settings defaulting to true

### DIFF
--- a/lib/rails-settings/setting_object.rb
+++ b/lib/rails-settings/setting_object.rb
@@ -46,7 +46,11 @@ module RailsSettings
 
   private
     def _get_value(name)
-      value[name] || _target_class.default_settings[var.to_sym][name]
+      if value[name].nil?
+        _target_class.default_settings[var.to_sym][name]
+      else
+        value[name]
+      end
     end
 
     def _set_value(name, v)


### PR DESCRIPTION
In the setting_object getter, the value of a setting is given by

value[name] || _target_class.default_settings[var.to_sym][name]

This causes a problem if a setting's default is true. Here's an example:

has_settings do |s|
    s.key :dashboard, :defaults => { :theme => 'blue', :view => 'monthly', :filter => true }
    s.key :calendar,  :defaults => { :scope => 'company'}
end

Here's the :filter setting in the :dashboard namespace is set to true as a default. When filter gets set to false, however, you can see the problem. In the getter, value[:filter] would return false, but because the getter uses the || operator and the default is true, the :filter setting will always return true.

To solve this, I only return the default value if the setting is nil.
