### PR TITLE
allow {} for value, since {}.blank? == true

### DIFF
--- a/lib/rails-settings/setting_object.rb
+++ b/lib/rails-settings/setting_object.rb
@@ -4,8 +4,9 @@ module RailsSettings
 
     belongs_to :target, :polymorphic => true
 
-    validates_presence_of :var, :value, :target_type
+    validates_presence_of :var, :target_type
     validate do
+      errors.add(:value, "Invalid key value") unless value.is_a? Hash
       unless _target_class.default_settings[var.to_sym]
         errors.add(:var, "#{var} is not defined!")
       end


### PR DESCRIPTION
there may be a better way to handle this, but without something like this, one can't remove (set to nil) the last key in the hash (e.g. reset all settings for key to defaults).
