### PR TITLE
Fix bug in to_settings_hash

### DIFF
--- a/lib/rails-settings/base.rb
+++ b/lib/rails-settings/base.rb
@@ -36,7 +36,7 @@ module RailsSettings
         end
 
         def to_settings_hash
-          settings_hash = self.class.default_settings
+          settings_hash = self.class.default_settings.dup
           settings_hash.each do |var, vals|
             settings_hash[var] = settings_hash[var].merge(settings(var.to_sym).value)
           end


### PR DESCRIPTION
Fix the unintended update of class `default_settings` when to_settings_hash is called on an instance.
