### PR TITLE
allow empty value setting

### DIFF
--- a/lib/rails-settings/setting_object.rb
+++ b/lib/rails-settings/setting_object.rb
@@ -4,8 +4,10 @@ module RailsSettings
 
     belongs_to :target, :polymorphic => true
 
-    validates_presence_of :var, :value, :target_type
+    validates_presence_of :var, :target_type
     validate do
+      errors.add(:value, "Invalid setting value") unless value.is_a? Hash
+
       unless _target_class.default_settings[var.to_sym]
         errors.add(:var, "#{var} is not defined!")
       end

--- a/spec/setting_object_spec.rb
+++ b/spec/setting_object_spec.rb
@@ -109,7 +109,7 @@ describe RailsSettings::SettingObject do
     end
 
     it 'should not save blank hash' do
-      new_setting_object.update_attributes({}).should be_false
+      new_setting_object.update_attributes({}).should be_true
     end
 
     if ActiveRecord::VERSION::MAJOR < 4

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -39,6 +39,23 @@ describe 'Objects' do
       account.settings(:portal).value.should eq({})
     end
 
+    it 'should allow saving a blank value' do
+      account.save!
+      account.settings(:portal).save.should be_true
+    end
+
+    it 'should allow removing all values' do
+      account.settings(:portal).premium = true
+      account.settings(:portal).fee = 42.5
+      account.save!
+
+      account.settings(:portal).premium = nil
+      account.save.should be_true
+
+      account.settings(:portal).fee = nil
+      account.save.should be_true
+    end
+
     it 'should not add settings on saving' do
       account.save!
       RailsSettings::SettingObject.count.should eq(0)


### PR DESCRIPTION
Prior to this PR, there was no way to delete every setting, because then the `value` attribute would be blank, which was forbidden with a validation.

This PR removes the `validates_presence_of` for `value`.
Now it is possible to delete all settings by setting all to `nil`.
I added a few tests and updated one existing test to reflect the new behaviour.

closes #39
(which addresses the same problem, but without proper tests)
