### PR TITLE
add readme about deleting settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ user.settings(:calendar).scope
 # => 'all'
 ```
 
+### Delete settings
+
+```ruby
+user = User.find(1)
+user.settings(:dashboard).update_attributes! :theme => nil
+
+user.settings(:dashboard).view = nil
+user.settings(:dashboard).save!
+```
 
 ### Using scopes
 


### PR DESCRIPTION
This PR adds a short description to the `README` on how to delete settings by setting them to `nil` and save afterwards.
