### PR TITLE
Adding persistent option to has_settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,26 @@ class ProjectSettingObject < RailsSettings::SettingObject
 end
 ```
 
+In case you need to define settings separatedly for the same models, you can use the persistent option
+
+```ruby
+module UserDashboardConcern
+  extend ActiveSupport::Concern
+
+  included do
+    has_settings persistent: true do |s|
+      s.key :dashboard
+    end
+  end
+end
+
+class User < ActiveRecord::Base
+  has_settings persistent: true do |s|
+    s.key :calendar
+  end
+end
+```
+
 ### Set settings
 
 ```ruby

--- a/lib/rails-settings/configuration.rb
+++ b/lib/rails-settings/configuration.rb
@@ -8,8 +8,15 @@ module RailsSettings
       raise ArgumentError unless klass
 
       @klass = klass
-      @klass.class_attribute :default_settings, :setting_object_class_name
-      @klass.default_settings = {}
+
+      if options[:persistent]
+        @klass.class_attribute :default_settings unless @klass.methods.include?(:default_settings)
+      else
+        @klass.class_attribute :default_settings
+      end
+
+      @klass.class_attribute :setting_object_class_name
+      @klass.default_settings ||= {}
       @klass.setting_object_class_name = options[:class_name] || 'RailsSettings::SettingObject'
 
       if block_given?

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -61,6 +61,18 @@ module RailsSettings
       expect(Dummy.default_settings).to eq({ :dashboard => {}, :calendar => {} })
       expect(Dummy.setting_object_class_name).to eq('MyClass')
     end
+
+    context 'persistent' do
+      it "should keep settings between multiple configurations initialization" do
+        Configuration.new(Dummy, :persistent => true) do |c|
+          c.key :dashboard, :defaults => { :theme => 'red' }
+        end
+
+        Configuration.new(Dummy, :calendar, :persistent => true)
+
+        expect(Dummy.default_settings).to eq({ :dashboard => { 'theme' => 'red' }, :calendar => {} })
+      end
+    end
   end
 
   describe Configuration, 'failure' do


### PR DESCRIPTION
Hello,

Thanks for the great work with this gem. It is very useful for us.

In my project, I need to define some settings in a Concern and then another set of settings in the model. Currently, the configuration class resets the default_settings in every has_settings call.
To allow settings additions I added a persistent option. I realize the code could be better. However, initially, I would like you to analyze if this type of solution is acceptable.

Thanks again.