### PR TITLE
Fix setting object method regex

### DIFF
--- a/lib/rails-settings/setting_object.rb
+++ b/lib/rails-settings/setting_object.rb
@@ -21,8 +21,8 @@ module RailsSettings
       attr_accessible
     end
 
-    REGEX_SETTER = /\A([a-z]\w+)=\Z/i
-    REGEX_GETTER = /\A([a-z]\w+)\Z/i
+    REGEX_SETTER = /\A([a-z]\w*)=\Z/i
+    REGEX_GETTER = /\A([a-z]\w*)\Z/i
 
     def respond_to?(method_name, include_priv=false)
       super || method_name.to_s =~ REGEX_SETTER || _setting?(method_name)

--- a/spec/setting_object_spec.rb
+++ b/spec/setting_object_spec.rb
@@ -22,6 +22,7 @@ describe RailsSettings::SettingObject do
       it "should respond to setters" do
         expect(new_setting_object).to respond_to(:foo=)
         expect(new_setting_object).to respond_to(:bar=)
+        expect(new_setting_object).to respond_to(:x=)
       end
 
       it "should not respond to some getters" do
@@ -44,12 +45,14 @@ describe RailsSettings::SettingObject do
       it "should return nil for unknown attribute" do
         expect(new_setting_object.foo).to eq(nil)
         expect(new_setting_object.bar).to eq(nil)
+        expect(new_setting_object.c).to eq(nil)
       end
 
       it "should return defaults" do
         expect(new_setting_object.theme).to eq('blue')
         expect(new_setting_object.view).to eq('monthly')
         expect(new_setting_object.filter).to eq(true)
+        expect(new_setting_object.a).to eq('b')
       end
 
       it "should return defaults when using `try`" do

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -251,6 +251,6 @@ describe "to_settings_hash" do
   end
 
   it "should return merged settings" do
-    expect(user.to_settings_hash).to eq({:dashboard=>{"filter"=>true, "owner_name"=>"Mr. Vishal", "sound"=>11, "theme"=>"green", "view"=>"monthly"}, :calendar=>{"scope"=>"some"}})
+    expect(user.to_settings_hash).to eq({:dashboard=>{"a"=>"b", "filter"=>true, "owner_name"=>"Mr. Vishal", "sound"=>11, "theme"=>"green", "view"=>"monthly"}, :calendar=>{"scope"=>"some"}})
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,7 +45,7 @@ end
 
 class User < ActiveRecord::Base
   has_settings do |s|
-    s.key :dashboard, :defaults => { :theme => 'blue', :view => 'monthly', :filter => true, owner_name: -> (target) { target.name } }
+    s.key :dashboard, :defaults => { :theme => 'blue', :view => 'monthly', :a => 'b', :filter => true, owner_name: -> (target) { target.name } }
     s.key :calendar,  :defaults => { :scope => 'company'}
   end
 end


### PR DESCRIPTION
Fixes #106 by modifying the `REGEX_GETTER` and `REGEX_SETTER` patterns in `RailsSettings::SettingObject` to allow for single character settings keys.
