### PR TITLE
Fix mutable default settings bug

### DIFF
--- a/lib/rails-settings/setting_object.rb
+++ b/lib/rails-settings/setting_object.rb
@@ -55,14 +55,25 @@ module RailsSettings
   private
     def _get_value(name)
       if value[name].nil?
-        if _target_class.default_settings[var.to_sym][name].respond_to?(:call)
-          _target_class.default_settings[var.to_sym][name].call(target)
-        else
-          _target_class.default_settings[var.to_sym][name]
-        end
+        default_value = _get_default_value(name)
+        _deep_dup(default_value)
       else
         value[name]
       end
+    end
+  
+    def _get_default_value(name)
+      default_value = _target_class.default_settings[var.to_sym][name]
+  
+      if default_value.respond_to?(:call)
+        default_value.call(target)
+      else
+        default_value
+      end
+    end
+  
+    def _deep_dup(nested_hashes_and_or_arrays)
+      Marshal.load(Marshal.dump(nested_hashes_and_or_arrays))
     end
 
     def _set_value(name, v)

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -135,11 +135,22 @@ describe 'Objects' do
       expect(RailsSettings::SettingObject.first.value).to eq({ 'theme' => 'brown' })
     end
 
-    it "should not mutate default settings" do
-      expected_return_value = User.default_settings[:calendar]['events'].dup
+    context "when default value is an Array" do
+      it "should not mutate default_settings" do
+        expected_return_value = User.default_settings[:calendar]['events'].dup
 
-      user.settings(:calendar).events.push('new_value')
-      expect(User.default_settings[:calendar]['events']).to eq(expected_return_value)
+        user.settings(:calendar).events.push('new_value')
+        expect(User.default_settings[:calendar]['events']).to eq(expected_return_value)
+      end
+    end
+
+    context "when default value is a Hash" do
+      it "should not mutate default_settings" do
+        expected_return_value = User.default_settings[:calendar]['profile'].dup
+
+        user.settings(:calendar).profile.update('new_key' => 'new_value')
+        expect(User.default_settings[:calendar]['profile']).to eq(expected_return_value)
+      end
     end
   end
 end
@@ -258,6 +269,6 @@ describe "to_settings_hash" do
   end
 
   it "should return merged settings" do
-    expect(user.to_settings_hash).to eq({:dashboard=>{"filter"=>true, "owner_name"=>"Mr. Vishal", "sound"=>11, "theme"=>"green", "view"=>"monthly"}, :calendar=>{"scope"=>"some", "events"=>[]}})
+    expect(user.to_settings_hash).to eq({:dashboard=>{"filter"=>true, "owner_name"=>"Mr. Vishal", "sound"=>11, "theme"=>"green", "view"=>"monthly"}, :calendar=>{"scope"=>"some", "events"=>[], "profile"=>{}}})
   end
 end

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -251,6 +251,6 @@ describe "to_settings_hash" do
   end
 
   it "should return merged settings" do
-    expect(user.to_settings_hash).to eq({:dashboard=>{"filter"=>true, "owner_name"=>"Mr. Vishal", "sound"=>11, "theme"=>"green", "view"=>"monthly"}, :calendar=>{"scope"=>"some"}})
+    expect(user.to_settings_hash).to eq({:dashboard=>{"filter"=>true, "owner_name"=>"Mr. Vishal", "sound"=>11, "theme"=>"green", "view"=>"monthly"}, :calendar=>{"scope"=>"some", "events"=>[]}})
   end
 end

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -134,6 +134,13 @@ describe 'Objects' do
       expect(RailsSettings::SettingObject.count).to eq(1)
       expect(RailsSettings::SettingObject.first.value).to eq({ 'theme' => 'brown' })
     end
+
+    it "should not mutate default settings" do
+      expected_return_value = User.default_settings[:calendar]['events'].dup
+
+      user.settings(:calendar).events.push('new_value')
+      expect(User.default_settings[:calendar]['events']).to eq(expected_return_value)
+    end
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ end
 class User < ActiveRecord::Base
   has_settings do |s|
     s.key :dashboard, :defaults => { :theme => 'blue', :view => 'monthly', :filter => true, owner_name: -> (target) { target.name } }
-    s.key :calendar,  :defaults => { :scope => 'company', :events => [] }
+    s.key :calendar,  :defaults => { :scope => 'company', :events => [], :profile => {} }
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ end
 class User < ActiveRecord::Base
   has_settings do |s|
     s.key :dashboard, :defaults => { :theme => 'blue', :view => 'monthly', :filter => true, owner_name: -> (target) { target.name } }
-    s.key :calendar,  :defaults => { :scope => 'company'}
+    s.key :calendar,  :defaults => { :scope => 'company', :events => [] }
   end
 end
 


### PR DESCRIPTION
## Overview

Fixes #108.

- Modifies `RailsSettings::SettingObject#_get_value` so that it returns a "deep dup" of the default value, as opposed to a direct reference to the default value.
- Adds tests for the cases where a default value is an Array or Hash

## How to test
Pull in `RailsSettings::SettingObject` from `master` and run tests:
```
git co master lib/rails-settings/setting_object.rb
bundle exec rspec
```

The new tests fail (along with an additional test that is affected by this, since `User.default_settings` gets modified).

Alternatively, you can use the code in the issue referenced above to reproduce.

## Notes
This approach to using `Marshal` to deep dup an object is documented in the book "The Ruby Programming Language" (page 83):
> Another use for Marshal.dump and Marshal.load is to create deep copies of objects:
> 
> ```ruby
> def deepcopy(o)
>   Marshal.load(Marshal.dump(o))
> end
> ```

_Flanagan, David. The Ruby Programming Language. “O’Reilly Media, Inc.,” 2008._