### PR TITLE
Fix serialize type deprecation warning on Rails 7.1+

### DIFF
--- a/lib/rails-settings/setting_object.rb
+++ b/lib/rails-settings/setting_object.rb
@@ -13,7 +13,7 @@ module RailsSettings
       end
     end
 
-    if Rails.version >= "7.1"
+    if ActiveRecord.version >= "7.1.0.beta1"
       serialize :value, type: Hash
     else
       serialize :value, Hash

--- a/lib/rails-settings/setting_object.rb
+++ b/lib/rails-settings/setting_object.rb
@@ -13,7 +13,11 @@ module RailsSettings
       end
     end
 
-    serialize :value, Hash
+    if Rails.version >= "7.1"
+      serialize :value, type: Hash
+    else
+      serialize :value, Hash
+    end
 
     if RailsSettings.can_protect_attributes?
       # attr_protected can not be used here because it touches the database which is not connected yet.

--- a/lib/rails-settings/setting_object.rb
+++ b/lib/rails-settings/setting_object.rb
@@ -1,6 +1,6 @@
 module RailsSettings
   class SettingObject < ActiveRecord::Base
-    self.table_name = "settings"
+    self.table_name = 'settings'
 
     belongs_to :target, :polymorphic => true
 
@@ -13,7 +13,7 @@ module RailsSettings
       end
     end
 
-    if ActiveRecord.version >= Gem::Version.new("7.1.0.beta1")
+    if ActiveRecord.version >= "7.1.0.beta1"
       serialize :value, type: Hash
     else
       serialize :value, Hash
@@ -28,7 +28,7 @@ module RailsSettings
     REGEX_SETTER = /\A([a-z]\w*)=\Z/i
     REGEX_GETTER = /\A([a-z]\w*)\Z/i
 
-    def respond_to?(method_name, include_priv = false)
+    def respond_to?(method_name, include_priv=false)
       super || method_name.to_s =~ REGEX_SETTER || _setting?(method_name)
     end
 
@@ -36,7 +36,7 @@ module RailsSettings
       if block_given?
         super
       else
-        if attribute_names.include?(method_name.to_s.sub("=", ""))
+        if attribute_names.include?(method_name.to_s.sub('=',''))
           super
         elsif method_name.to_s =~ REGEX_SETTER && args.size == 1
           _set_value($1, args.first)
@@ -48,15 +48,15 @@ module RailsSettings
       end
     end
 
-    protected
+  protected
     if RailsSettings.can_protect_attributes?
       # Simulate attr_protected by removing all regular attributes
       def sanitize_for_mass_assignment(attributes, role = nil)
-        attributes.except("id", "var", "value", "target_id", "target_type", "created_at", "updated_at")
+        attributes.except('id', 'var', 'value', 'target_id', 'target_type', 'created_at', 'updated_at')
       end
     end
 
-    private
+  private
     def _get_value(name)
       if value[name].nil?
         default_value = _get_default_value(name)
@@ -65,17 +65,17 @@ module RailsSettings
         value[name]
       end
     end
-
+  
     def _get_default_value(name)
       default_value = _target_class.default_settings[var.to_sym][name]
-
+  
       if default_value.respond_to?(:call)
         default_value.call(target)
       else
         default_value
       end
     end
-
+  
     def _deep_dup(nested_hashes_and_or_arrays)
       Marshal.load(Marshal.dump(nested_hashes_and_or_arrays))
     end

--- a/lib/rails-settings/setting_object.rb
+++ b/lib/rails-settings/setting_object.rb
@@ -13,7 +13,7 @@ module RailsSettings
       end
     end
 
-    if ActiveRecord.version >= "7.1.0.beta1"
+    if ActiveRecord.version >= Gem::Version.new("7.1.0.beta1")
       serialize :value, type: Hash
     else
       serialize :value, Hash

--- a/lib/rails-settings/setting_object.rb
+++ b/lib/rails-settings/setting_object.rb
@@ -1,6 +1,6 @@
 module RailsSettings
   class SettingObject < ActiveRecord::Base
-    self.table_name = 'settings'
+    self.table_name = "settings"
 
     belongs_to :target, :polymorphic => true
 
@@ -13,7 +13,7 @@ module RailsSettings
       end
     end
 
-    if ActiveRecord.version >= "7.1.0.beta1"
+    if ActiveRecord.version >= Gem::Version.new("7.1.0.beta1")
       serialize :value, type: Hash
     else
       serialize :value, Hash
@@ -28,7 +28,7 @@ module RailsSettings
     REGEX_SETTER = /\A([a-z]\w*)=\Z/i
     REGEX_GETTER = /\A([a-z]\w*)\Z/i
 
-    def respond_to?(method_name, include_priv=false)
+    def respond_to?(method_name, include_priv = false)
       super || method_name.to_s =~ REGEX_SETTER || _setting?(method_name)
     end
 
@@ -36,7 +36,7 @@ module RailsSettings
       if block_given?
         super
       else
-        if attribute_names.include?(method_name.to_s.sub('=',''))
+        if attribute_names.include?(method_name.to_s.sub("=", ""))
           super
         elsif method_name.to_s =~ REGEX_SETTER && args.size == 1
           _set_value($1, args.first)
@@ -48,15 +48,15 @@ module RailsSettings
       end
     end
 
-  protected
+    protected
     if RailsSettings.can_protect_attributes?
       # Simulate attr_protected by removing all regular attributes
       def sanitize_for_mass_assignment(attributes, role = nil)
-        attributes.except('id', 'var', 'value', 'target_id', 'target_type', 'created_at', 'updated_at')
+        attributes.except("id", "var", "value", "target_id", "target_type", "created_at", "updated_at")
       end
     end
 
-  private
+    private
     def _get_value(name)
       if value[name].nil?
         default_value = _get_default_value(name)
@@ -65,17 +65,17 @@ module RailsSettings
         value[name]
       end
     end
-  
+
     def _get_default_value(name)
       default_value = _target_class.default_settings[var.to_sym][name]
-  
+
       if default_value.respond_to?(:call)
         default_value.call(target)
       else
         default_value
       end
     end
-  
+
     def _deep_dup(nested_hashes_and_or_arrays)
       Marshal.load(Marshal.dump(nested_hashes_and_or_arrays))
     end


### PR DESCRIPTION
Upgrading to Rails 7.1 is giving me this warning when my app boots:

```
DEPRECATION WARNING: Passing the class as positional argument is deprecated and will be removed in Rails 7.2.

Please pass the class as a keyword argument:

  serialize :value, type: Hash
```

This fixes it.