### PR TITLE
Fix NoMethodError on Rails 7.x when running rails g rails_settings:migration

### DIFF
--- a/lib/generators/rails_settings/migration/migration_generator.rb
+++ b/lib/generators/rails_settings/migration/migration_generator.rb
@@ -14,11 +14,16 @@ module RailsSettings
     end
 
     def self.next_migration_number(dirname)
-      if ActiveRecord::Base.timestamped_migrations
+      if timestamped_migrations?
         Time.now.utc.strftime('%Y%m%d%H%M%S')
       else
         '%.3d' % (current_migration_number(dirname) + 1)
       end
+    end
+
+    def self.timestamped_migrations?
+      (ActiveRecord::Base.respond_to?(:timestamped_migrations) && ActiveRecord::Base.timestamped_migrations) ||
+      (ActiveRecord.respond_to?(:timestamped_migrations) && ActiveRecord.timestamped_migrations)
     end
   end
 end


### PR DESCRIPTION
When attempting to run `rails g rails_settings:migration` in a Rails `7.x` project, the generator fails with a `NoMethodError` out of `activerecord-7.1.0/lib/active_record/dynamic_matchers.rb:22`

The `timestamped_migrations` method was moved from `ActiveRecord::Base` to `ActiveRecord` in the `7.x` branch, see https://github.com/rails/rails/commit/bcd6c0f3d03500bfc4c0c9830302d5ad54c2c81d