### PR TITLE
Support Ruby 2.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
+          - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ruby gem to handle settings for ActiveRecord instances by storing them as serial
 
 ## Requirements
 
-- Ruby 3.0 or newer
+- Ruby 2.7 or newer
 - Rails 6.1 or newer (including Rails 7.0)
 
 ## Installation

--- a/rails-settings.gemspec
+++ b/rails-settings.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.summary =
     'Ruby gem to handle settings for ActiveRecord instances by storing them as serialized Hash in a separate database table. Namespaces and defaults included.'
   gem.homepage = 'https://github.com/ledermann/rails-settings'
-  gem.required_ruby_version = '>= 3.0'
+  gem.required_ruby_version = '>= 2.7'
 
   gem.files = `git ls-files`.split($/)
   gem.executables = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }


### PR DESCRIPTION
Following the [Rails Guides](https://guides.rubyonrails.org/v7.1/upgrading_ruby_on_rails.html), Rails 7 requires Ruby 2.7.0 or newer.