### PR TITLE
Defer the inclusion until after ActiveRecord has been fully loaded, improving booting performance and following Rails best practices

### DIFF
--- a/lib/rails-settings.rb
+++ b/lib/rails-settings.rb
@@ -11,11 +11,13 @@ require 'rails-settings/configuration'
 require 'rails-settings/base'
 require 'rails-settings/scopes'
 
-ActiveRecord::Base.class_eval do
-  def self.has_settings(*args, &block)
-    RailsSettings::Configuration.new(*args.unshift(self), &block)
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::Base.class_eval do
+    def self.has_settings(*args, &block)
+      RailsSettings::Configuration.new(*args.unshift(self), &block)
 
-    include RailsSettings::Base
-    extend RailsSettings::Scopes
+      include RailsSettings::Base
+      extend RailsSettings::Scopes
+    end
   end
 end


### PR DESCRIPTION

**Issue Description**
The current implementation references ActiveRecord on gem load which triggers premature loading of Active Record. This can significantly slow down application boot time, especially in development and test environments.

**Solution**
Use Rails recommended [ActiveSupport.on_load(:active_record)](https://edgeapi.rubyonrails.org/classes/ActiveSupport/LazyLoadHooks.html) hook to defer module inclusion until after ActiveRecord is fully loaded. This improves boot performance and avoids potential load order issues in edge cases.